### PR TITLE
Add .vs gitignore rule to root folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Root folder ignore case for .vs. If we need to add something from here to version control, we can do it manually with `git add -f .vs/<path>`
+.vs/


### PR DESCRIPTION
Removing .vs folder through .gitignore in the root folder, so as to match the .gitignore in api/CodeEditorApi/. See https://stackoverflow.com/questions/31878901/should-i-add-the-visual-studio-2015-vs-folder-to-source-control for further rationale.