### PR TITLE
Chores

### DIFF
--- a/api/CodeEditorApi/CodeEditorApi/Helpers/JwtHelper.cs
+++ b/api/CodeEditorApi/CodeEditorApi/Helpers/JwtHelper.cs
@@ -17,7 +17,7 @@ namespace CodeEditorApi.Helpers
             {
                 new Claim(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
                 new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
-                new Claim(ClaimTypes.Role, Enum.GetName(Roles.Student))
+                new Claim(ClaimTypes.Role, Enum.GetName(typeof(Roles), user.RoleId))
             };
 
             var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(secret));


### PR DESCRIPTION
The role was hardcoded as 'Student' in JwtHelper, which meant that we'd never be properly returning the role to the api when handing it a token.