### PR TITLE
Fix course deletion

### DIFF
--- a/app/src/modules/Courses/Courses.js
+++ b/app/src/modules/Courses/Courses.js
@@ -122,10 +122,7 @@ async function deleteCourse(id, token) {
 
     if (isValid) {
         try { 
-            let response = await instance.delete("/Courses/DeleteCourse", {
-                data: {
-                    id: id
-                },
+            let response = await instance.delete("/Courses/" + id, {
                 headers: {...headers},
             });
 


### PR DESCRIPTION
I forgot to switch this over to the new api route. Should be fine now.
delete->api/Courses/DeleteCourses => delete->api/Courses/{id}