### PR TITLE
createTutorial validation for duplicate tutorial Title

### DIFF
--- a/api/CodeEditorApi/CodeEditorApi/Features/Tutorials/CreateTutorials/CreateTutorialsCommand.cs
+++ b/api/CodeEditorApi/CodeEditorApi/Features/Tutorials/CreateTutorials/CreateTutorialsCommand.cs
@@ -1,8 +1,7 @@
-﻿using CodeEditorApiDataAccess.Data;
+﻿using CodeEditorApi.Errors;
+using CodeEditorApi.Features.Tutorials.GetTutorials;
+using CodeEditorApiDataAccess.Data;
 using Microsoft.AspNetCore.Mvc;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace CodeEditorApi.Features.Tutorials.CreateTutorials
@@ -14,14 +13,21 @@ namespace CodeEditorApi.Features.Tutorials.CreateTutorials
     public class CreateTutorialsCommand : ICreateTutorialsCommand
     {
         private readonly ICreateTutorials _createTutorials;
+        private readonly IGetTutorials _getTutorials;
 
-        public CreateTutorialsCommand(ICreateTutorials createTutorials)
+        public CreateTutorialsCommand(ICreateTutorials createTutorials, IGetTutorials getTutorials)
         {
             _createTutorials = createTutorials;
+            _getTutorials = getTutorials;
         }
 
         public async Task<ActionResult<Tutorial>> ExecuteAsync(CreateTutorialsBody createTutorialsBody)
         {
+            var tutorialsInCourse = await _getTutorials.GetCourseTutorials(createTutorialsBody.CourseId);
+            if (tutorialsInCourse.Find(t => t.Title == createTutorialsBody.Title) != null)
+            {
+                return ApiError.BadRequest($"A tutorial already exists under course {createTutorialsBody.CourseId} with the same title '{createTutorialsBody.Title}'");
+            }
             return await _createTutorials.ExecuteAsync(createTutorialsBody);
         }
     }

--- a/api/CodeEditorApi/CodeEditorApiUnitTests/Features/Tutorials/CreateTutorialsCommandTest.cs
+++ b/api/CodeEditorApi/CodeEditorApiUnitTests/Features/Tutorials/CreateTutorialsCommandTest.cs
@@ -1,9 +1,13 @@
 ﻿using AutoFixture;
+using CodeEditorApi.Errors;
 using CodeEditorApi.Features.Tutorials.CreateTutorials;
+using CodeEditorApi.Features.Tutorials.GetTutorials;
 using CodeEditorApiDataAccess.Data;
 using CodeEditorApiUnitTests.Helpers;
 using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
 using Moq;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -23,6 +27,35 @@ namespace CodeEditorApiUnitTests.Features.Tutorials
 
             actionResult.Should().NotBeNull();
             actionResult.Value.Should().Be(tutorial);
+        }
+
+        [Fact]
+        public async Task ShouldReturnBadRequestOnDuplicateTutorialTitle()
+        {
+            var courseId = fixture.Create<int>();
+            var title = fixture.Create<string>();
+            var body = fixture.Build<CreateTutorialsBody>()
+                .With(b => b.CourseId, courseId)
+                .With(b => b.Title, title)
+                .Create();
+
+            var tutorials = fixture.Build<Tutorial>()
+                .With(t => t.CourseId, courseId)
+                .With(t => t.Title, title)
+                .CreateMany()
+                .ToList();
+
+
+            var expected = new BadRequestError($"A tutorial already exists under course {courseId} with the same title '{title}'");
+
+            Freeze<IGetTutorials>().Setup(g => g.GetCourseTutorials(courseId)).ReturnsAsync(tutorials);
+            Freeze<ICreateTutorials>().Setup(c => c.ExecuteAsync(body)).ReturnsAsync((Tutorial)null);
+
+            var actionResult = await Target().ExecuteAsync(body);
+
+            var result = actionResult.Result as BadRequestObjectResult;
+            result.Should().NotBeNull();
+            result.Value.Should().BeEquivalentTo(expected);
         }
     }
 }


### PR DESCRIPTION
if a tutorial is created with the exact same title as another tutorial under the same course it's connected to, then that tutorial cannot be created and a fault is thrown. Should be caught by the UI eventually