### PR TITLE
new route called GetUserTutorialDetails

### DIFF
--- a/api/CodeEditorApi/CodeEditorApi/Features/Tutorials/GetTutorials/GetTutorials.cs
+++ b/api/CodeEditorApi/CodeEditorApi/Features/Tutorials/GetTutorials/GetTutorials.cs
@@ -20,7 +20,10 @@ namespace CodeEditorApi.Features.Tutorials.GetTutorials
         public Task<Tutorial> GetUserLastInProgressTutorial(int userId, int courseId);
 
         public Task<List<UserTutorial>> GetUserRegisteredTutorials(int courseId, int userId);
+
         public Task<List<UserTutorial>> GetUserRegisteredTutorials(int userId);
+
+        public Task<List<UserTutorialDetailsBody>> GetUserRegisteredTutorialsWithCourseTutorialDetails(int courseId, int userId);
     }
     public class GetTutorials : IGetTutorials
     {
@@ -60,6 +63,24 @@ namespace CodeEditorApi.Features.Tutorials.GetTutorials
                 .Select(ut => ut).ToListAsync();
 
             return inProgressTutorials;
+        }
+
+        public async Task<List<UserTutorialDetailsBody>> GetUserRegisteredTutorialsWithCourseTutorialDetails(int courseId, int userId)
+        {
+            var userTutorialsDetails = await _context.Tutorials.Where(t => t.CourseId == courseId).Join(
+                _context.UserTutorials.Where(ut => ut.UserId == userId), t => t.Id,
+                ut => ut.TutorialId,
+                (Tutorials, UserTutorials) => new UserTutorialDetailsBody(
+                    Tutorials.Id, 
+                    UserTutorials.UserId, 
+                    Tutorials.DifficultyId, 
+                    Tutorials.LanguageId, 
+                    UserTutorials.InProgress, 
+                    UserTutorials.IsCompleted)
+                
+                ).ToListAsync();
+
+            return userTutorialsDetails;
         }
 
         public async Task<List<UserTutorial>> GetUserRegisteredTutorials(int userId)

--- a/api/CodeEditorApi/CodeEditorApi/Features/Tutorials/GetTutorials/GetUserTutorialsDetailsCommand.cs
+++ b/api/CodeEditorApi/CodeEditorApi/Features/Tutorials/GetTutorials/GetUserTutorialsDetailsCommand.cs
@@ -1,0 +1,27 @@
+﻿using CodeEditorApi.Features.Tutorials.UpdateTutorials;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CodeEditorApi.Features.Tutorials.GetTutorials
+{
+    public interface IGetUserTutorialsDetailsCommand
+    {
+        public Task<ActionResult<List<UserTutorialDetailsBody>>> ExecuteAsync(int courseId, int userId);
+    }
+    public class GetUserTutorialsDetailsCommand : IGetUserTutorialsDetailsCommand
+    {
+        private readonly IGetTutorials _getTutorials;
+
+        public GetUserTutorialsDetailsCommand(IGetTutorials getTutorials)
+        {
+            _getTutorials = getTutorials;
+        }
+        public async Task<ActionResult<List<UserTutorialDetailsBody>>> ExecuteAsync(int courseId, int userId)
+        {
+            return await _getTutorials.GetUserRegisteredTutorialsWithCourseTutorialDetails(courseId, userId);
+        }
+    }
+}

--- a/api/CodeEditorApi/CodeEditorApi/Features/Tutorials/GetTutorials/UserTutorialDetailsBody.cs
+++ b/api/CodeEditorApi/CodeEditorApi/Features/Tutorials/GetTutorials/UserTutorialDetailsBody.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace CodeEditorApi.Features.Tutorials.GetTutorials
+{
+    public class UserTutorialDetailsBody
+    {
+        public int Id { get; set; }
+        public int UserId { get; set; }
+        public int? DifficultyId { get; set; }
+        public int? LanguageId { get; set; }
+        public bool InProgress { get; set; }
+        public bool IsCompleted { get; set; }
+
+        public UserTutorialDetailsBody(int Id, int UserId, int? DifficultyId, int? LanguageId, bool InProgress, bool IsCommpleted)
+        {
+            this.Id = Id;
+            this.UserId = UserId;
+            this.DifficultyId = DifficultyId;
+            this.LanguageId = LanguageId;
+            this.InProgress = InProgress;
+            this.IsCompleted = IsCommpleted;
+        }
+    }
+
+}

--- a/api/CodeEditorApi/CodeEditorApi/Features/Tutorials/TutorialsController.cs
+++ b/api/CodeEditorApi/CodeEditorApi/Features/Tutorials/TutorialsController.cs
@@ -25,12 +25,14 @@ namespace CodeEditorApi.Features.Tutorials
         private readonly IUpdateUserTutorialsCommand _updateUserTutorialsCommand;
         private readonly IUnregisterUserCommand _unregisterUserCommand;
         private readonly IGetUserTutorialsPerCourseCommand _getUserTutorialsPerCourseCommand;
+        private readonly IGetUserTutorialsDetailsCommand _getUserTutorialsDetailsCommand;
 
         public TutorialsController(IGetTutorialsCommand getTutorialsCommand, ICreateTutorialsCommand createTutorialsCommand,
             IDeleteTutorialsCommand deleteTutorialsCommand, IUpdateTutorialsCommand updateTutorialsCommand,
             IGetUserCreatedTutorialsCommand getUserCreatedTutorialsCommand, IGetCourseTutorialsCommand getCourseTutorialsCommand,
             IGetUserLastInProgressTutorialCommand getUserLastInProgressTutorialCommand, IUpdateUserTutorialsCommand updateUserTutorialsCommand,
-            IUnregisterUserCommand unregisterUserCommand, IGetUserTutorialsPerCourseCommand getUserTutorialsPerCourseCommand)
+            IUnregisterUserCommand unregisterUserCommand, IGetUserTutorialsPerCourseCommand getUserTutorialsPerCourseCommand,
+            IGetUserTutorialsDetailsCommand getUserTutorialsDetailsCommand)
         {
             _getTutorialsCommand = getTutorialsCommand;
             _createTutorialsCommand = createTutorialsCommand;
@@ -42,6 +44,7 @@ namespace CodeEditorApi.Features.Tutorials
             _updateUserTutorialsCommand = updateUserTutorialsCommand;
             _unregisterUserCommand = unregisterUserCommand;
             _getUserTutorialsPerCourseCommand = getUserTutorialsPerCourseCommand;
+            _getUserTutorialsDetailsCommand = getUserTutorialsDetailsCommand;
         }
 
         /// <summary>
@@ -94,11 +97,28 @@ namespace CodeEditorApi.Features.Tutorials
             
         }
 
+        /// <summary>
+        /// Get A User's Tutorial statuses for a specific Course
+        /// </summary>
+        /// <param name="courseId"></param>
+        /// <returns></returns>
         [HttpGet("GetUserTutorialsOnCourse/{courseId:int}")]
         public async Task<ActionResult<List<UserTutorial>>> GetUserTutorialsPerCourse(int courseId)
         {
             var userId = HttpContextHelper.retrieveRequestUserId(HttpContext);
             return await _getUserTutorialsPerCourseCommand.ExecuteAsync(courseId, userId);
+        }
+
+        /// <summary>
+        /// Get User's progress on each Tutorial for a specific Course AND the details of that Tutorial
+        /// </summary>
+        /// <param name="courseId"></param>
+        /// <returns></returns>
+        [HttpGet("GetUserTutorialsDetails/{courseId:int}")]
+        public async Task<ActionResult<List<UserTutorialDetailsBody>>> GetUserTutorialsDetails(int courseId)
+        {
+            var userId = HttpContextHelper.retrieveRequestUserId(HttpContext);
+            return await _getUserTutorialsDetailsCommand.ExecuteAsync(courseId, userId);
         }
 
         /// <summary>

--- a/api/CodeEditorApi/CodeEditorApiUnitTests/Features/Tutorials/GetUserTutorialDetailsCommandTest.cs
+++ b/api/CodeEditorApi/CodeEditorApiUnitTests/Features/Tutorials/GetUserTutorialDetailsCommandTest.cs
@@ -1,0 +1,34 @@
+﻿using AutoFixture;
+using CodeEditorApi.Features.Tutorials.GetTutorials;
+using CodeEditorApiDataAccess.Data;
+using CodeEditorApiUnitTests.Helpers;
+using FluentAssertions;
+using Moq;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace CodeEditorApiUnitTests.Features.Tutorials
+{
+    public class GetUserTutorialDetailsCommandTest : UnitTest<GetUserTutorialsDetailsCommand>
+    {
+        [Fact]
+        public async Task ShouldReturnUserTutorialDetailsBodyList()
+        {
+            var userId = It.IsAny<int>();
+            var courseId = It.IsAny<int>();
+
+            var userTutorialDetails = fixture.Build<UserTutorialDetailsBody>()
+                .With(utdb => utdb.UserId, userId)
+                .CreateMany().ToList();
+
+            Freeze<IGetTutorials>().Setup(gt => gt.GetUserRegisteredTutorialsWithCourseTutorialDetails(courseId, userId)).ReturnsAsync(userTutorialDetails);
+
+            var actionResult = await Target().ExecuteAsync(courseId, userId);
+
+            actionResult.Result.Should().BeNull();
+            actionResult.Value.Should().BeEquivalentTo(userTutorialDetails);
+
+        }
+    }
+}


### PR DESCRIPTION
gets both Tutorial info for Course page and User's status per each Tutorial

- We should use this route for going onto a Course page where the User has already been registered.
     * It gives you Tutorial information for displaying Tags, and information to display the correct button next to each Tutorial ('Start', 'Continue,' 'Restart')
   
- The `GetCourseTutorials` route can still be used for an Unregistered Course page state.