### PR TITLE
Remove isRegistered check on tutorialDetails

### DIFF
--- a/app/pages/courses/[id].js
+++ b/app/pages/courses/[id].js
@@ -23,7 +23,7 @@ export async function getServerSideProps(context) {
     const isRegistered = await checkIfInCourse(id, token);
 
     const tutorials = await getTutorialsFromCourse(id, token);
-    const tutorialDetails = (isRegistered) ? await getUserTutorialsDetailsFromCourse(id, token) : false;
+    const tutorialDetails = await getUserTutorialsDetailsFromCourse(id, token);
     tutorials.forEach(function(tute) {
         const thisCourseIndex = tutorialDetails.findIndex(tuteDetails => tute.id == tuteDetails.id); // it's possible a tutorial added after someone registers for a course doesnt have a tutorialDetails
         if (isRegistered && thisCourseIndex == -1)


### PR DESCRIPTION
As Cruiz mentioned, a user not being registered for a course will just return an empty array from getUserTutorialsDetailsFromCourse. Fixes the 500 error on visiting a course.