### PR TITLE
adding UserCode to UserTutorial and UpdateUserTutorial

### DIFF
--- a/api/CodeEditorApi/CodeEditorApi/Features/Tutorials/UpdateTutorials/UpdateUserTutorialBody.cs
+++ b/api/CodeEditorApi/CodeEditorApi/Features/Tutorials/UpdateTutorials/UpdateUserTutorialBody.cs
@@ -10,5 +10,8 @@ namespace CodeEditorApi.Features.Tutorials.UpdateTutorials
 
         [Required]
         public bool IsCompleted { get; set; }
+
+        [Required]
+        public string UserCode { get; set; }
     }
 }

--- a/api/CodeEditorApi/CodeEditorApiData/Tables/UserTutorial.sql
+++ b/api/CodeEditorApi/CodeEditorApiData/Tables/UserTutorial.sql
@@ -5,6 +5,7 @@
     [InProgress] BIT NOT NULL, 
     [IsCompleted] BIT NOT NULL, 
     [ModifyDate] DATETIME NULL, 
+    [UserCode] TEXT NULL, 
     PRIMARY KEY ([UserId], [TutorialId]), 
     CONSTRAINT [FK_UserTutorial_Tutorial] FOREIGN KEY ([TutorialId]) REFERENCES [Tutorial]([Id]), 
     CONSTRAINT [FK_UserTutorial_User] FOREIGN KEY ([UserId]) REFERENCES [User]([Id])


### PR DESCRIPTION
requires UserCode on updateTutorial
UserCode can be null (mainly for initial creation of a UserTutorial where a User may not have started the Tutorial, therefore not having any edited "UserCode")