### PR TITLE
Add override for JS/CSS in dbLanguageToMonacoLanguage

### DIFF
--- a/app/src/common/utils/static.js
+++ b/app/src/common/utils/static.js
@@ -57,8 +57,8 @@ const dbLanguageToMonacoLanguage = {
     HTML: 'html',
     Java: 'java',
     Python: 'python',
-    Javascript: 'javascript',
-    CSS: 'css',
+    Javascript: 'html', // edge case
+    CSS: 'html', // edge case
 }
 
 function ShouldLanguageCompile(language) {


### PR DESCRIPTION
Because our CSS / Javascript tutorials have their respective elements embedded within an HTML document, we need to set the monaco editor language to 'html' behind the curtain. This is easy enough. 