### PR TITLE
forgot to return all tutorials 

### DIFF
--- a/api/CodeEditorApi/CodeEditorApi/Features/Tutorials/GetTutorials/GetTutorials.cs
+++ b/api/CodeEditorApi/CodeEditorApi/Features/Tutorials/GetTutorials/GetTutorials.cs
@@ -166,6 +166,11 @@ namespace CodeEditorApi.Features.Tutorials.GetTutorials
                         })
                         .ToList();
             }
+            //else return all published tutorials under that course
+            else
+            {
+                return tutorials;
+            }
 
             return query;
         }


### PR DESCRIPTION
under a course for a completely empty search (get all courses/tutorials search)